### PR TITLE
Fix libxslt package on Debian systems

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,7 +15,7 @@ class riemann::params {
     'Debian': {
       $service_provider = upstart
       $libxml_package = 'libxml2-dev'
-      $libxslt_package = 'libxslt-dev'
+      $libxslt_package = 'libxslt1-dev'
     }
     'RedHat', 'Amazon': {
       include epel

--- a/spec/classes/riemann/dash_spec.rb
+++ b/spec/classes/riemann/dash_spec.rb
@@ -11,7 +11,7 @@ describe 'riemann::dash', :type => :class do
   it { should contain_class('gcc')}
   it { should contain_package('riemann-dash')}
   it { should contain_package('libxml2-dev')}
-  it { should contain_package('libxslt-dev')}
+  it { should contain_package('libxslt1-dev')}
   it { should contain_service('riemann-dash').with_provider('upstart')}
   it { should contain_file('/etc/riemann-dash.rb').with_content(/localhost/)}
   it { should contain_file('/etc/riemann-dash.rb').with_content(/4567/)}

--- a/spec/classes/riemann/tools_spec.rb
+++ b/spec/classes/riemann/tools_spec.rb
@@ -8,7 +8,7 @@ describe 'riemann::tools', :type => :class do
   it { should contain_package('riemann-tools').with_provider('gem')}
   it { should contain_package('riemann-client').with_provider('gem')}
   it { should contain_package('libxml2-dev')}
-  it { should contain_package('libxslt-dev')}
+  it { should contain_package('libxslt1-dev')}
   it { should contain_class('gcc')}
 
   context 'with services disabled' do


### PR DESCRIPTION
libxslt-dev is a virtual package installing libxslt1-dev, so Puppet will
try to install it on each run, even if the real package was already
installed.
