### PR TITLE
Manage config for saving riemann dashboard config to s3.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,8 @@ via another puppet resource or otherwise.
 For a fully working example of this module you may also be interested in
 the [riemann-vagrant
 project](https://github.com/garethr/riemann-vagrant).
+
+ # Archival Note 
+ This repository is deprecated; therefore, we are going to archive it. However, learners will be able to fork it to their personal Github account but cannot submit PRs to this repository. If you have any issues or suggestions to make, feel free to: 
+- Utilize the https://knowledge.udacity.com/ forum to seek help on content-specific issues. 
+- Submit a support ticket along with the link to your forked repository if (learners are) blocked for other reasons. Here are the links for the [retail consumers](https://udacity.zendesk.com/hc/en-us/requests/new) and [enterprise learners](https://udacityenterprise.zendesk.com/hc/en-us/requests/new?ticket_form_id=360000279131).

--- a/manifests/dash.pp
+++ b/manifests/dash.pp
@@ -25,7 +25,7 @@ class riemann::dash(
   $s3_config = $riemann::params::dash_s3_config,
   $ws_config = $riemann::params::dash_ws_config,
   $rvm_ruby_string = $riemann::params::rvm_ruby_string,
-  $use_s3 = ($riemann::params::dash_s3_config != {})
+  $use_s3 = ($s3_config != {})
 ) inherits riemann::params {
   validate_string($host)
   validate_string($user)

--- a/manifests/dash.pp
+++ b/manifests/dash.pp
@@ -25,6 +25,7 @@ class riemann::dash(
   $s3_config = $riemann::params::dash_s3_config,
   $ws_config = $riemann::params::dash_ws_config,
   $rvm_ruby_string = $riemann::params::rvm_ruby_string,
+  $use_s3 = ($riemann::params::dash_s3_config != {})
 ) inherits riemann::params {
   validate_string($host)
   validate_string($user)

--- a/manifests/dash.pp
+++ b/manifests/dash.pp
@@ -22,6 +22,8 @@ class riemann::dash(
   $host = $riemann::params::dash_host,
   $port = $riemann::params::dash_port,
   $user = $riemann::params::dash_user,
+  $s3_config = $riemann::params::dash_s3_config,
+  $ws_config = $riemann::params::dash_ws_config,
   $rvm_ruby_string = $riemann::params::rvm_ruby_string,
 ) inherits riemann::params {
   validate_string($host)
@@ -31,4 +33,3 @@ class riemann::dash(
   class { 'riemann::dash::service': } ->
   Class['riemann::dash']
 }
-

--- a/manifests/dash.pp
+++ b/manifests/dash.pp
@@ -24,8 +24,7 @@ class riemann::dash(
   $user = $riemann::params::dash_user,
   $s3_config = $riemann::params::dash_s3_config,
   $ws_config = $riemann::params::dash_ws_config,
-  $rvm_ruby_string = $riemann::params::rvm_ruby_string,
-  $use_s3 = ($s3_config != {})
+  $rvm_ruby_string = $riemann::params::rvm_ruby_string
 ) inherits riemann::params {
   validate_string($host)
   validate_string($user)

--- a/manifests/dash/config.pp
+++ b/manifests/dash/config.pp
@@ -2,6 +2,8 @@ class riemann::dash::config {
   $host = $riemann::dash::host
   $port = $riemann::dash::port
   $user = $riemann::dash::user
+  $s3_config = $riemann::dash::s3_config
+  $ws_config = $riemann::dash::ws_config
   $rvm_ruby_string = $riemann::dash::rvm_ruby_string
 
   case $::osfamily {

--- a/manifests/dash/install.pp
+++ b/manifests/dash/install.pp
@@ -13,4 +13,20 @@ class riemann::dash::install {
     require  => Class['gcc'],
     provider => gem,
   }
+
+  if ($riemann::dash::use_s3) {
+    case $::osfamily {
+      'debian': {
+        package {'ruby-dev':
+          ensure => "present"
+        }
+      }
+    }
+    ->
+    package {'fog':
+      ensure   => "present",
+      provider => "gem",
+      require  => Package['ruby-dev'];
+    }
+  }
 }

--- a/manifests/dash/install.pp
+++ b/manifests/dash/install.pp
@@ -17,10 +17,13 @@ class riemann::dash::install {
   if ($riemann::dash::use_s3) {
     case $::osfamily {
       'debian': {
-        ensure_resource('package', 'ruby-dev', {'ensure' => 'present'})
+        ensure_resource('package', 'ruby-dev', {'ensure' => 'present' })
       }
     }
-    ->
-    ensure_resource('package', 'fog', {'ensure' => 'present', 'provider' => 'gem'})
+    ensure_resource('package', 'fog', {
+      'ensure' => 'present',
+      'provider' => 'gem',
+      'require' => Package['ruby-dev']
+    })
   }
 }

--- a/manifests/dash/install.pp
+++ b/manifests/dash/install.pp
@@ -17,16 +17,10 @@ class riemann::dash::install {
   if ($riemann::dash::use_s3) {
     case $::osfamily {
       'debian': {
-        package {'ruby-dev':
-          ensure => "present"
-        }
+        ensure_resource('package', 'ruby-dev', {'ensure' => 'present'})
       }
     }
     ->
-    package {'fog':
-      ensure   => "present",
-      provider => "gem",
-      require  => Package['ruby-dev'];
-    }
+    ensure_resource('package', 'fog', {'ensure' => 'present', 'provider' => 'gem'})
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,6 +4,8 @@ class riemann::params {
   $dash_port = 4567
   $dash_host = 'localhost'
   $dash_user = 'riemann-dash'
+  $dash_s3_config = {}
+  $dash_ws_config = '/var/lib/riemann-dash/layout.json'
   $net_user = 'riemann-net'
   $health_user = 'riemann-health'
   $port = 5555

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,7 +4,7 @@ class riemann::params {
   $dash_port = 4567
   $dash_host = 'localhost'
   $dash_user = 'riemann-dash'
-  $dash_s3_config = {}
+  $dash_s3_config = undef
   $dash_ws_config = '/var/lib/riemann-dash/layout.json'
   $net_user = 'riemann-net'
   $health_user = 'riemann-health'

--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
   "version": "0.6.0",
   "author": "Gareth Rushgrove",
   "summary": "Module for installing and managing the Riemann monitoring tool",
-  "license": "Apache License, Version 2.0",
+  "license": "Apache-2.0",
   "source": "git://github.com/garethr/garethr-riemann",
   "project_page": "https://github.com/garethr/garethr-riemann",
   "issues_url": "https://github.com/garethr/garethr-riemann/issues",

--- a/templates/etc/riemann-dash.rb.erb
+++ b/templates/etc/riemann-dash.rb.erb
@@ -1,3 +1,6 @@
 set :bind, '<%= @host %>'
 set :port, <%= @port %>
-config[:ws_config] = '/var/lib/riemann-dash/layout.json'
+config[:ws_config] = '<%= @ws_config %>'
+<% unless @s3_config.empty? %>
+config[:s3_config] = <%= @s3_config.to_s %>
+<% end %>

--- a/templates/etc/riemann-dash.rb.erb
+++ b/templates/etc/riemann-dash.rb.erb
@@ -1,6 +1,6 @@
 set :bind, '<%= @host %>'
 set :port, <%= @port %>
 config[:ws_config] = '<%= @ws_config %>'
-<% unless @s3_config.empty? %>
+<% unless @s3_config %>
 config[:s3_config] = <%= @s3_config.to_s %>
 <% end %>


### PR DESCRIPTION
This is pretty much working, but might need some cleanup to get up to snuff (I'm still relatively new to puppet). One known hole is that the default value for for `use_s3` doesn't work. I don't know how to fix it, but I figure you might (or perhaps my fine fellow udacian, @ods94065, knows how?).

Happy to work out any concerns you have to get this merged, just let me know what needs doing. Would be nice to get #14 in shortly thereafter, too, so we can switch back to using the version from the forge.
