### PR TITLE
[Test-Support] Add Vagrant configuration for testing in VM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ pkg
 spec/fixtures
 .rspec_system
 .bundle
+modules
+vendor
+.vagrant
+.librarian

--- a/Gemfile
+++ b/Gemfile
@@ -14,4 +14,5 @@ group :development do
   gem "travis"
   gem "travis-lint"
   gem "puppet-blacksmith"
+  gem "librarian-puppet"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,8 +9,18 @@ GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (2.2.8)
+    activemodel (4.1.8)
+      activesupport (= 4.1.8)
+      builder (~> 3.1)
+    activesupport (4.1.8)
+      i18n (~> 0.6, >= 0.6.9)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.1)
+      tzinfo (~> 1.1)
     addressable (2.3.6)
     backports (3.6.4)
+    builder (3.2.2)
     coderay (1.1.0)
     diff-lcs (1.2.5)
     ethon (0.7.1)
@@ -29,17 +39,31 @@ GEM
       multi_json (~> 1.0)
       net-http-persistent (>= 2.7)
       net-http-pipeline
+    her (0.7.2)
+      activemodel (>= 3.0.0, < 4.2)
+      activesupport (>= 3.0.0, < 4.2)
+      faraday (>= 0.8, < 1.0)
+      multi_json (~> 1.7)
     hiera (1.3.4)
       json_pure
     highline (1.6.21)
+    i18n (0.6.11)
     json (1.8.1)
     json_pure (1.8.1)
     launchy (2.4.3)
       addressable (~> 2.3)
+    librarian (0.1.2)
+      highline
+      thor (~> 0.15)
+    librarian-puppet (2.0.1)
+      librarian (>= 0.1.2)
+      puppet_forge
+      rsync
     metaclass (0.0.4)
     metadata-json-lint (0.0.2)
     method_source (0.8.2)
     mime-types (2.4.3)
+    minitest (5.4.3)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
     multi_json (1.10.1)
@@ -61,6 +85,8 @@ GEM
     puppet-lint (1.1.0)
     puppet-syntax (1.3.0)
       rake
+    puppet_forge (1.0.3)
+      her (~> 0.6)
     puppetlabs_spec_helper (0.8.2)
       mocha
       puppet-lint
@@ -83,7 +109,10 @@ GEM
     rspec-expectations (2.99.2)
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.99.2)
+    rsync (1.0.9)
     slop (3.6.0)
+    thor (0.19.1)
+    thread_safe (0.3.4)
     travis (1.7.4)
       addressable (~> 2.3)
       backports
@@ -99,12 +128,15 @@ GEM
       json
     typhoeus (0.6.9)
       ethon (>= 0.7.1)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
     websocket (1.2.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  librarian-puppet
   metadata-json-lint
   puppet (~> 3.7.0)
   puppet-blacksmith

--- a/README.md
+++ b/README.md
@@ -43,3 +43,14 @@ via another puppet resource or otherwise.
 For a fully working example of this module you may also be interested in
 the [riemann-vagrant
 project](https://github.com/garethr/riemann-vagrant).
+
+## Testing
+
+For manual integration testing during development, there is a Vagrant box
+which can be used as follows (only installs the +riemann+ module by default):
+
+```
+bundle install
+bundle exec librarian-puppet install
+vagrant up
+```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,15 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "puppetlabs/centos-6.5-64-puppet"
+  config.vm.hostname = 'puppet-riemann'
+  config.vm.synced_folder "modules", "/tmp/puppet-modules", type: "rsync", rsync__exclude: ".git/"
+  config.vm.synced_folder ".", "/tmp/puppet-modules/riemann", type: "rsync", rsync__exclude: ".git/"
+
+  config.vm.provision :puppet do |puppet|
+    puppet.manifests_path = "tests"
+    puppet.manifest_file  = "vagrant.pp"
+    puppet.options        = ["--modulepath", "/tmp/puppet-modules"]
+  end
+end

--- a/tests/vagrant.pp
+++ b/tests/vagrant.pp
@@ -1,0 +1,1 @@
+class { 'riemann': }


### PR DESCRIPTION
This PR adds a Centos 6 Vagrant box that can be used for easy integration testing when working on garethr-riemann.

There is some overlap to riemann-vagrant but having an integrated Vagrant configuration simplifies integration testing a lot.

I have not written any tests because I couldn't find a sensible thing to test. If you have something you'd like to have tested, I'll gladly provide that.
