### PR TITLE
Allow user to specify mirror location for Riemann archive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: ruby
 bundler_args: --without development
 before_install: rm Gemfile.lock || true
 rvm:
-  - 1.8.7
   - 1.9.3
   - 2.0.0
   - 2.1.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,4 @@ env:
   - PUPPET_VERSION="~> 3.5.0"
   - PUPPET_VERSION="~> 3.6.0"
   - PUPPET_VERSION="~> 3.7.0"
+sudo: false

--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ configuration file.
 In this last case you're responsible for making sure that file exists,
 via another puppet resource or otherwise.
 
+By default, this module will attempt to download the .bz2 archive from
+aphyr.com, run by the author of Riemann. An alternative source can be
+provided: 
+
+	class { 'riemann': source => 'http://myserver.corp', path=> '/riemann/' } 
+
 ## Example
 
 For a fully working example of this module you may also be interested in

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,6 +26,8 @@ class riemann(
   $host = $riemann::params::host,
   $port = $riemann::params::port,
   $user = $riemann::params::user,
+  $source = $riemann::params::source,
+  $source_path = $riemann::params::source_path,
 ) inherits riemann::params {
 
   validate_absolute_path($config_file)

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -16,7 +16,7 @@ class riemann::install {
   }
 
   wget::fetch { 'download_riemann':
-    source      => "http://aphyr.com/riemann/riemann-${riemann::version}.tar.bz2",
+    source      => "${riemann::source}/${riemann::source_path}/riemann-${riemann::version}.tar.bz2",
     destination => "/usr/local/src/riemann-${riemann::version}.tar.bz2",
     before      => Exec['untar_riemann'],
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,6 +9,8 @@ class riemann::params {
   $port = 5555
   $host = 'localhost'
   $user = 'riemann'
+  $source = 'http://aphyr.com/'
+  $source_path = 'riemann/'
   $rvm_ruby_string = undef
 
   case $::osfamily {

--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
   "version": "0.6.0",
   "author": "Gareth Rushgrove",
   "summary": "Module for installing and managing the Riemann monitoring tool",
-  "license": "Apache License 2.0",
+  "license": "Apache-2.0",
   "source": "git://github.com/garethr/garethr-riemann",
   "project_page": "https://github.com/garethr/garethr-riemann",
   "issues_url": "https://github.com/garethr/garethr-riemann/issues",

--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
   "version": "0.6.0",
   "author": "Gareth Rushgrove",
   "summary": "Module for installing and managing the Riemann monitoring tool",
-  "license": "Apache License, Version 2.0",
+  "license": "Apache License 2.0",
   "source": "git://github.com/garethr/garethr-riemann",
   "project_page": "https://github.com/garethr/garethr-riemann",
   "issues_url": "https://github.com/garethr/garethr-riemann/issues",


### PR DESCRIPTION
I'm on a protected network where I can't connect to aphyr to grab the archives, so I extended the module to allow me to specify the mirror URL. 

Please let me know if you have any questions. Thanks! 

--Matt 
