### PR TITLE
fix failing tests and typo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ language: ruby
 bundler_args: --without development
 before_install: rm Gemfile.lock || true
 rvm:
-  - 1.8.7
-  - 1.9.3
   - 2.0.0
   - 2.1.0
 script: bundle exec rake test

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,7 +4,7 @@
 #
 # === Parameters
 # [*version*]
-#   The version of riemann to instal
+#   The version of riemann to install
 #
 # [*config_file*]
 #   File path for a riemann config file. A default file is provided. If

--- a/metadata.json
+++ b/metadata.json
@@ -3,15 +3,11 @@
   "version": "0.6.0",
   "author": "Gareth Rushgrove",
   "summary": "Module for installing and managing the Riemann monitoring tool",
-  "license": "Apache License, Version 2.0",
+  "license": "Apache-2.0",
   "source": "git://github.com/garethr/garethr-riemann",
   "project_page": "https://github.com/garethr/garethr-riemann",
   "issues_url": "https://github.com/garethr/garethr-riemann/issues",
   "requirements": [
-    {
-      "name": "pe",
-      "version_requirement": "3.x"
-    },
     {
       "name": "puppet",
       "version_requirement": "3.x"


### PR DESCRIPTION
fix typo

fix license specifier to match spdx list

remove 'pe' requirement from metadata.json

The 'pe' requirement is no longer supported by the Forge.

remove Ruby 1.x support in Travis CI config